### PR TITLE
introduced remove_surrounding_characters attack

### DIFF
--- a/Adversary/attacks.py
+++ b/Adversary/attacks.py
@@ -1,5 +1,6 @@
 from random import choice, randint, sample, randrange
 from string import punctuation
+import re
 
 from Adversary.constants import *
 
@@ -91,6 +92,11 @@ def num_to_word(word):
     return NUM_TO_WORD.get(word, word)
 
 
+def remove_surrounding_characters(word):
+    regex = re.compile('[^a-zA-Z]')
+    return regex.sub('', word)
+
+
 '''Keeps track of all attacks and their types'''
 
 
@@ -108,6 +114,7 @@ ATTACK_MAP = {
         'insert_duplicate_characters': insert_duplicate_characters,
         'delete_characters': delete_characters,
         'change_case': change_case,
-        'num_to_word': num_to_word
+        'num_to_word': num_to_word,
+        'remove_surrounding_characters': remove_surrounding_characters
     }
 }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ metrics_single, metrics_group = gen.attack(texts_original, texts_generated, lamb
     - Deleting characters (`delete_characters`)
     - Changing case (`change_case`)
     - Replacing digits with words (`num_to_word`)
+    - Removes special characters around letters (`remove_surrounding_characters`)
 
 ### Interface:
 

--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -3,3 +3,8 @@ from Adversary.attacks import *
 def test_num_to_word():
     assert(num_to_word('1') == 'one')
     assert(num_to_word('dog') == 'dog')
+
+def test_remove_surrounding_characters():
+    assert(remove_surrounding_characters('(b)(a)(n)(k)') == 'bank')
+    assert(remove_surrounding_characters('[l]uigi') == 'luigi')
+    assert(remove_surrounding_characters('mario') == 'mario')


### PR DESCRIPTION
Introduced `remove_surrounding_characters` attack, created tests for the attack and included it in the `README.md` doc. 

This covers word-level attacks for example:
words like `[b][o][w][s][e][r]` will be converted to `bowser`